### PR TITLE
Restore appending the text/html header to support web page rendering

### DIFF
--- a/src/Microsoft.HybridConnections.Core/HttpListener.cs
+++ b/src/Microsoft.HybridConnections.Core/HttpListener.cs
@@ -135,9 +135,8 @@ namespace Microsoft.HybridConnections.Core
                 context.Response.Headers.Add(header.Key, string.Join(",", header.Value));
             }
 
-            // Note: the following line has been commented out as the client app should add this header every time the response has text/html payload.
             // To support Web page rendering 
-            // context.Response.Headers.Add(HttpRequestHeader.ContentType, "text/html; charset=UTF-8");
+            context.Response.Headers.Add(HttpRequestHeader.ContentType, "text/html; charset=UTF-8");
 
             var responseStream = await responseMessage.Content.ReadAsStreamAsync();
             await responseStream.CopyToAsync(context.Response.OutputStream);


### PR DESCRIPTION
Paired with @bcage29 to test on both of our machines and restoring this commented line (in `HttpListener.cs`) seems to be the preferable approach here, making it work properly for both of us!